### PR TITLE
BugFix in selectedUsers in groupChat creation

### DIFF
--- a/frontend/src/components/miscellaneous/GroupChatModal.js
+++ b/frontend/src/components/miscellaneous/GroupChatModal.js
@@ -79,7 +79,7 @@ const GroupChatModal = ({ children }) => {
   };
 
   const handleSubmit = async () => {
-    if (!groupChatName || !selectedUsers) {
+    if (!groupChatName || !selectedUsers.length) {
       toast({
         title: "Please fill all the feilds",
         status: "warning",


### PR DESCRIPTION
BugFix: selectedUsers is initialized to empty array so !selectedUsers will give false and won't work if array is empty. 
