### PR TITLE
feat(chat): Implement unread message notifications in MyChats

### DIFF
--- a/frontend/src/components/MyChats.js
+++ b/frontend/src/components/MyChats.js
@@ -1,23 +1,38 @@
 import { AddIcon } from "@chakra-ui/icons";
-import { Box, Stack, Text } from "@chakra-ui/layout";
+import { Box, Stack, Text, Flex } from "@chakra-ui/layout";
 import { useToast } from "@chakra-ui/toast";
 import axios from "axios";
-import { useEffect, useState } from "react";
+// MODIFIED: Import useEffect, useState, and useCallback
+import { useEffect, useState, useCallback } from "react";
 import { getSender } from "../config/ChatLogics";
 import ChatLoading from "./ChatLoading";
 import GroupChatModal from "./miscellaneous/GroupChatModal";
-import { Button } from "@chakra-ui/react";
+import { Button, Badge } from "@chakra-ui/react";
 import { ChatState } from "../Context/ChatProvider";
 
 const MyChats = ({ fetchAgain }) => {
   const [loggedUser, setLoggedUser] = useState();
 
-  const { selectedChat, setSelectedChat, user, chats, setChats } = ChatState();
+  const {
+    selectedChat,
+    setSelectedChat,
+    user,
+    chats,
+    setChats,
+    notification,
+    setNotification,
+    onlineUsers,
+  } = ChatState();
 
   const toast = useToast();
 
-  const fetchChats = async () => {
-    // console.log(user._id);
+  // MODIFIED: Wrap fetchChats in useCallback
+  const fetchChats = useCallback(async () => {
+    // We check for 'user' here to prevent running on initial load if user isn't ready
+    if (!user) {
+      return;
+    }
+
     try {
       const config = {
         headers: {
@@ -37,17 +52,20 @@ const MyChats = ({ fetchAgain }) => {
         position: "bottom-left",
       });
     }
-  };
+    // MODIFIED: Add dependencies for useCallback
+  }, [user, setChats, toast]); // Include all external variables used inside
 
   useEffect(() => {
-    setLoggedUser(JSON.parse(localStorage.getItem("userInfo")));
-    fetchChats();
-    // eslint-disable-next-line
-  }, [fetchAgain]);
+    if (user) {
+      setLoggedUser(JSON.parse(localStorage.getItem("userInfo")));
+      fetchChats(); // Now this is safe to call
+    }
+    // MODIFIED: Add fetchChats to the dependency array
+  }, [fetchAgain, user, fetchChats]); // 'fetchChats' is now stable
 
   return (
     <Box
-      d={{ base: selectedChat ? "none" : "flex", md: "flex" }}
+      display={{ base: selectedChat ? "none" : "flex", md: "flex" }}
       flexDir="column"
       alignItems="center"
       p={3}
@@ -56,12 +74,13 @@ const MyChats = ({ fetchAgain }) => {
       borderRadius="lg"
       borderWidth="1px"
     >
+      {/* ... (Rest of your component code is unchanged) ... */}
       <Box
         pb={3}
         px={3}
         fontSize={{ base: "28px", md: "30px" }}
         fontFamily="Work sans"
-        d="flex"
+        display="flex"
         w="100%"
         justifyContent="space-between"
         alignItems="center"
@@ -69,7 +88,7 @@ const MyChats = ({ fetchAgain }) => {
         My Chats
         <GroupChatModal>
           <Button
-            d="flex"
+            display="flex"
             fontSize={{ base: "17px", md: "10px", lg: "17px" }}
             rightIcon={<AddIcon />}
           >
@@ -78,7 +97,7 @@ const MyChats = ({ fetchAgain }) => {
         </GroupChatModal>
       </Box>
       <Box
-        d="flex"
+        display="flex"
         flexDir="column"
         p={3}
         bg="#F8F8F8"
@@ -89,32 +108,82 @@ const MyChats = ({ fetchAgain }) => {
       >
         {chats ? (
           <Stack overflowY="scroll">
-            {chats.map((chat) => (
-              <Box
-                onClick={() => setSelectedChat(chat)}
-                cursor="pointer"
-                bg={selectedChat === chat ? "#38B2AC" : "#E8E8E8"}
-                color={selectedChat === chat ? "white" : "black"}
-                px={3}
-                py={2}
-                borderRadius="lg"
-                key={chat._id}
-              >
-                <Text>
-                  {!chat.isGroupChat
-                    ? getSender(loggedUser, chat.users)
-                    : chat.chatName}
-                </Text>
-                {chat.latestMessage && (
-                  <Text fontSize="xs">
-                    <b>{chat.latestMessage.sender.name} : </b>
-                    {chat.latestMessage.content.length > 50
-                      ? chat.latestMessage.content.substring(0, 51) + "..."
-                      : chat.latestMessage.content}
-                  </Text>
-                )}
-              </Box>
-            ))}
+            {chats.map((chat) => {
+              const otherUser =
+                loggedUser && !chat.isGroupChat
+                  ? chat.users.find((u) => u._id !== loggedUser._id)
+                  : null;
+
+              const isOnline = otherUser
+                ? onlineUsers.includes(otherUser._id)
+                : false;
+
+              const notificationCount = notification.filter(
+                (n) => n.chat._id === chat._id
+              ).length;
+
+              return (
+                <Box
+                  onClick={() => {
+                    setSelectedChat(chat);
+                    setNotification(
+                      notification.filter((n) => n.chat._id !== chat._id)
+                    );
+                  }}
+                  cursor="pointer"
+                  bg={selectedChat === chat ? "#38B2AC" : "#E8E8E8"}
+                  color={selectedChat === chat ? "white" : "black"}
+                  px={3}
+                  py={2}
+                  borderRadius="lg"
+                  key={chat._id}
+                >
+                  <Flex justifyContent="space-between" alignItems="center">
+                    <Flex alignItems="center" gap={2}>
+                      {loggedUser && !chat.isGroupChat && (
+                        <Box
+                          w="8px"
+                          h="8px"
+                          borderRadius="full"
+                          bg={isOnline ? "green.500" : "gray.400"}
+                          title={isOnline ? "Online" : "Offline"}
+                        />
+                      )}
+                      <Text>
+                        {!chat.isGroupChat
+                          ? getSender(loggedUser, chat.users)
+                          : chat.chatName}
+                      </Text>
+                    </Flex>
+                    {notificationCount > 0 && (
+                      <Badge
+                        colorScheme="green"
+                        borderRadius="full"
+                        px={2}
+                        fontSize="0.8em"
+                        title={`${notificationCount} new message${
+                          notificationCount > 1 ? "s" : ""
+                        }`}
+                      >
+                        {notificationCount}
+                      </Badge>
+                    )}
+                  </Flex>
+
+                  {chat.latestMessage && (
+                    <Text
+                      fontSize="xs"
+                      color={selectedChat === chat ? "gray.200" : "gray.600"}
+                    >
+                      <b>{chat.latestMessage.sender.name} : </b>
+                      {chat.latestMessage.content.length > 50
+                        ? chat.latestMessage.content.substring(0, 51) + "..."
+                        : chat.latestMessage.content}
+                    </Text>
+                  )}
+                </Box>
+              );
+            })}
           </Stack>
         ) : (
           <ChatLoading />


### PR DESCRIPTION
This PR adds:

- Real-time Count: Displays a numeric Badge in the MyChats list, showing the exact count of unread messages for each chat.
- Global State: Adds a notification state to ChatProvider to globally track incoming messages.
- Smart Logic: SingleChat is updated to push new messages to the notification state only if that chat is not currently open and 
    active.
- "Mark as Read": MyChats now renders the Badge with the unread count and automatically clears the notifications for a specific 
   chat when the user clicks on it.